### PR TITLE
Make socketio connections more generic

### DIFF
--- a/examples/demo/templates/index.html
+++ b/examples/demo/templates/index.html
@@ -59,7 +59,7 @@
           ],
           input: ''
         };
-        this.socket = io.connect('http://localhost:8080');
+        this.socket = io();
         this.chatbox = React.createRef()
       }
 


### PR DESCRIPTION
[io()](https://socket.io/docs/v4/client-api/#iourl) defaults to window.location.host. 

Useful for deploying to public networks