### PR TITLE
reduce CPU pressure

### DIFF
--- a/agency/spaces/amqp_space.py
+++ b/agency/spaces/amqp_space.py
@@ -138,6 +138,6 @@ class AMQPSpace(Space):
         connection = self.__agent_connections[agent.id()]
         connection.heartbeat_check()  # sends heartbeat if necessary
         try:
-            connection.drain_events(timeout=0)
+            connection.drain_events(timeout=0.01)
         except socket.timeout:
             pass

--- a/agency/spaces/amqp_space.py
+++ b/agency/spaces/amqp_space.py
@@ -138,6 +138,6 @@ class AMQPSpace(Space):
         connection = self.__agent_connections[agent.id()]
         connection.heartbeat_check()  # sends heartbeat if necessary
         try:
-            connection.drain_events(timeout=0.01)
+            connection.drain_events(timeout=0.001)
         except socket.timeout:
             pass


### PR DESCRIPTION
connection.drain_events(**timeout=0**)  will cause the computer to overheat (MacOS M1)

<img width="343" alt="image" src="https://github.com/operand/agency/assets/3153878/367a2077-a5c2-4c6b-a438-305c3b9a7268">
