### PR TITLE
Parameterization of Max Workers in ResourceManager

### DIFF
--- a/agency/resources.py
+++ b/agency/resources.py
@@ -9,14 +9,15 @@ class ResourceManager:
     _instance = None
     _initialized = False
 
-    def __new__(cls):
+    def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super(ResourceManager, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self):
+    def __init__(self, max_workers=None):
         if not self._initialized:
-            self.thread_pool_executor = ThreadPoolExecutor()
-            self.process_pool_executor = ProcessPoolExecutor()
+            self._max_workers = max_workers
+            self.thread_pool_executor = ThreadPoolExecutor(self._max_workers)
+            self.process_pool_executor = ProcessPoolExecutor(self._max_workers)
             self.multiprocessing_manager = multiprocessing.Manager()
             self._initialized = True

--- a/agency/spaces/local_space.py
+++ b/agency/spaces/local_space.py
@@ -31,10 +31,10 @@ class LocalSpace(Space):
     A LocalSpace allows Agents to communicate within the python application
     """
 
-    def __init__(self):
+    def __init__(self, max_workers=None):
         super().__init__()
         self._stop_router_event: threading.Event = threading.Event()
-        self._outbound_message_event: multiprocessing.Event = ResourceManager(
+        self._outbound_message_event: multiprocessing.Event = ResourceManager(max_workers
         ).multiprocessing_manager.Event()
         self._router_future: Future = self._start_router_thread()
 


### PR DESCRIPTION
This PR introduces a parameterization feature for the _ResourceManager_ class, allowing the number of maximum workers (**max_workers**) to be specified during the instantiation of the class. The addition of the max_workers parameter in the init method enables greater flexibility in configuring the concurrent execution environment. With this enhancement, users can now initialize the ResourceManager with a custom number of maximum workers, providing more control over the concurrent processing capabilities of the application.