### PR TITLE
fix(examples): guard against empty choices in LLM completion response

### DIFF
--- a/examples/demo/agents/openai_completion_agent.py
+++ b/examples/demo/agents/openai_completion_agent.py
@@ -73,5 +73,7 @@ class OpenAICompletionAgent(HelpMethods, SayResponseMethods, PromptMethods, Agen
           max_tokens=500,
         )
         # parse the output
+        if not completion.choices:
+            raise ValueError("LLM returned empty choices list")
         action = util.extract_json(completion.choices[0].text, ["/END"])
         self.send(action)


### PR DESCRIPTION
## What

Guards `completion.choices[0]` in `examples/demo/agents/openai_completion_agent.py` before accessing `.text`:

```python
# Before
action = util.extract_json(completion.choices[0].text, ["/END"])

# After
if not completion.choices:
    raise ValueError("LLM returned empty choices list")
action = util.extract_json(completion.choices[0].text, ["/END"])
```

## Why

The OpenAI Completions API can return `choices=[]` at HTTP 200 when content is filtered. Without the guard, this raises an unhandled `IndexError` that crashes the agent mid-action, losing any state built up during the conversation.

## Evidence

- [Live production crash](https://github.com/HKUDS/LightRAG/issues/2551) — confirmed in the wild from the same pattern
- Found by [pact](https://github.com/qizwiz/pact) across 13.5k violations in 759 repos

## Scope

1 file, 2 lines added.